### PR TITLE
build ol-geosearch: esm, cjs, browser

### DIFF
--- a/examples/openlayers-library-example/index.html
+++ b/examples/openlayers-library-example/index.html
@@ -24,7 +24,7 @@
   <script src="https://cdn.jsdelivr.net/npm/ol@7.1.0/dist/ol.js"></script>
 
   <script src="https://cdn.jsdelivr.net/npm/@opencage/geosearch-bundle"></script>
-  <script src="dist/ol-opencage-geosearch.js"></script>
+  <script src="dist/dist/ol-opencage-geosearch.umd.js"></script>
   <script src="config.js"></script>
 </head>
 

--- a/packages/ol-opencage-geosearch/ol-opencage-geosearch.js
+++ b/packages/ol-opencage-geosearch/ol-opencage-geosearch.js
@@ -1,5 +1,6 @@
 import Control from 'ol/control/Control';
 import { autocomplete } from '@algolia/autocomplete-js';
+// eslint-disable-next-line import/no-unresolved
 import { OpenCageGeoSearchPlugin } from '@opencage/geosearch-core';
 
 export default class OpenCageGeosearchControl extends Control {

--- a/packages/ol-opencage-geosearch/ol-opencage-geosearch.js
+++ b/packages/ol-opencage-geosearch/ol-opencage-geosearch.js
@@ -1,4 +1,8 @@
-class OpenCageGeosearchControl extends ol.control.Control {
+import Control from 'ol/control/Control';
+import { autocomplete } from '@algolia/autocomplete-js';
+import { OpenCageGeoSearchPlugin } from '@opencage/geosearch-core';
+
+export default class OpenCageGeosearchControl extends Control {
   constructor(options) {
     const pluginOptions = options || {};
 
@@ -15,10 +19,10 @@ class OpenCageGeosearchControl extends ol.control.Control {
 
     this.setCssPosition(this.options.position);
 
-    opencage.algoliaAutocomplete({
+    autocomplete({
       container: this.element,
       plugins: [
-        opencage.OpenCageGeoSearchPlugin(this.options, {
+        OpenCageGeoSearchPlugin(this.options, {
           onSelect: this.handleSelect.bind(this),
           onActive: this.options.onActive,
           onSubmit: this.options.onSubmit,

--- a/packages/ol-opencage-geosearch/package.json
+++ b/packages/ol-opencage-geosearch/package.json
@@ -30,17 +30,30 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "dist/",
+    "ol-opencage-geosearch.css",
+    "ol-opencage-geosearch.js"
+  ],
   "source": "ol-opencage-geosearch.js",
-  "main": "ol-opencage-geosearch.js",
+  "main": "dist/ol-opencage-geosearch.cjs.js",
+  "module": "dist/ol-opencage-geosearch.esm.js",
+  "browser": "dist/ol-opencage-geosearch.umd.js",
   "scripts": {
+    "build": "rollup -c",
+    "build:clean": "rm -rf dist",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test": "echo \"Warning: run tests from root\" && exit 0"
   },
-  "peerDependencies": {
+  "dependencies": {
+    "@opencage/geosearch-core": "^0.0.15",
+    "@algolia/autocomplete-js": "^1.7.1",
     "ol": "^7.1"
   },
   "devDependencies": {
-    "ol": "^7.1"
+    "@rollup/plugin-commonjs": "^22.0.2",
+    "@rollup/plugin-node-resolve": "^14.1.0",
+    "rollup": "^2.79.0"
   }
 }

--- a/packages/ol-opencage-geosearch/rollup.config.js
+++ b/packages/ol-opencage-geosearch/rollup.config.js
@@ -1,0 +1,53 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import pkg from './package.json';
+
+const source = 'ol-opencage-geosearch.js';
+
+const globals = {
+  'ol/control/Control': 'ol.control.Control',
+  '@algolia/autocomplete-js': 'autocomplete',
+  '@opencage/geosearch-core': 'OpenCageGeoSearchPlugin',
+};
+const external = [
+  'ol/control/Control',
+  '@algolia/autocomplete-js',
+  '@opencage/geosearch-core',
+];
+
+export default [
+  // browser-friendly UMD build
+  {
+    input: source,
+    external,
+    output: {
+      globals,
+      name: 'OpenCageGeosearchControl',
+      file: pkg.browser,
+      format: 'umd',
+      sourcemap: true,
+    },
+    plugins: [
+      resolve(),
+      commonjs({
+        exclude: 'src/**',
+        include: 'node_modules/**',
+      }),
+    ],
+  },
+
+  // CommonJS (for Node) and ES module (for bundlers) build.
+  // (We could have three entries in the configuration array
+  // instead of two, but it's quicker to generate multiple
+  // builds from a single configuration where possible, using
+  // an array for the `output` option, where we can specify
+  // `file` and `format` for each target)
+  {
+    input: source,
+    external,
+    output: [
+      { file: pkg.main, format: 'cjs' },
+      { file: pkg.module, format: 'es' },
+    ],
+  },
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,6 +2531,19 @@
     "@babel/helper-module-imports" "^7.10.4"
     "@rollup/pluginutils" "^3.1.0"
 
+"@rollup/plugin-commonjs@^22.0.2":
+  version "22.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz#ee8ca8415cda30d383b4096aad5222435b4b69b6"
+  integrity sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
 "@rollup/plugin-node-resolve@^11.2.1":
   version "11.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz#82aa59397a29cd4e13248b106e6a4a1880362a60"
@@ -2540,6 +2553,18 @@
     "@types/resolve" "1.17.1"
     builtin-modules "^3.1.0"
     deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/plugin-node-resolve@^14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-14.1.0.tgz#f2fa475405cd7fed6420bf438fe393f988a9bc96"
+  integrity sha512-5G2niJroNCz/1zqwXtk0t9+twOSDlG00k1Wfd7bkbbXmwg8H8dvgHdIWAun53Ps/rckfvOC7scDBjuGFg5OaWw==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    deepmerge "^4.2.2"
+    is-builtin-module "^3.1.0"
     is-module "^1.0.0"
     resolve "^1.19.0"
 
@@ -4026,6 +4051,11 @@ builtin-modules@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -5837,6 +5867,11 @@ estree-walker@^1.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -7026,6 +7061,13 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-builtin-module@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz#bb0310dfe881f144ca83f30100ceb10cf58835e0"
+  integrity sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -7042,6 +7084,13 @@ is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -7152,6 +7201,13 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -10838,6 +10894,15 @@ resolve@^1.10.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.2
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^1.17.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.3.tgz#d41016293d4a8586a39ca5d9b5f15cbea1f55e46"
@@ -10890,6 +10955,13 @@ rollup@^2.43.1:
   version "2.70.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.0.tgz#17a92e5938e92a251b962352e904c9f558230ec7"
   integrity sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+rollup@^2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.0.tgz#9177992c9f09eb58c5e56cbfa641607a12b57ce2"
+  integrity sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Uses rollup to build ol-opencage-geosearch pages. It fixes #182.