### PR TITLE
Refactor workflow and remove Sinon dependency

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# This workflow builds on Node LTS and tests the built artifact across multiple Node versions.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
@@ -11,6 +11,40 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Setup pnpm package manager
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm lint
+      - name: Test
+        run: pnpm test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Build
+        run: pnpm build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: geosearch-core-dist
+          path: packages/geosearch-core/dist/js/
+
+  test:
+    needs: build
     runs-on: ubuntu-latest
 
     strategy:
@@ -32,13 +66,10 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
-      - name: Lint
-        run: pnpm lint
-      - name: Test
-        run: pnpm test:coverage
-      - name: Build
-        run: pnpm build
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: geosearch-core-dist
+          path: packages/geosearch-core/dist/js/
+      - name: Test dist
+        run: pnpm --filter @opencage/geosearch-core test:dist

--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-security": "^3.0.1",
     "fetch-mock": "^12.6.0",
-    "globals": "^16.5.0",
+    "globals": "^17.6.0",
     "isomorphic-unfetch": "^4.0.2",
     "lerna": "^9.0.7",
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
     "prettier": "^3.8.3",
     "sass": "^1.100.0",
-    "sinon": "^21.1.2",
     "vite": "7.3.2",
     "vitest": "4.1.8"
   }

--- a/packages/geosearch-core/package.json
+++ b/packages/geosearch-core/package.json
@@ -52,6 +52,7 @@
     "lint:fix": "eslint --fix .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:dist": "vitest run --config vitest.dist.config.js",
     "watch": "vite build --watch"
   },
   "devDependencies": {

--- a/packages/geosearch-core/src/handleResult.js
+++ b/packages/geosearch-core/src/handleResult.js
@@ -40,8 +40,8 @@ export const handleResult = (
       onActive,
       // ----
       templates: {
-        item({ item }) {
-          return `${item.formatted}`;
+        item({ item, createElement }) {
+          return createElement('span', null, item.formatted);
         },
         noResults() {
           return noResults;

--- a/packages/geosearch-core/test/dist.spec.js
+++ b/packages/geosearch-core/test/dist.spec.js
@@ -1,0 +1,74 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import fetchMock from 'fetch-mock';
+
+// fetch polyfill
+import 'isomorphic-unfetch';
+
+// The Build Step should have generated this file, so we can test the actual dist output
+// But the first time the linter runs, it won't exist yet, so we ignore the error
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+import { OpenCageGeoSearchPlugin } from '../dist/js/opencage-geosearch-core.esm.js';
+import { payload } from './fixtures/greno-payload';
+
+const SOURCE_ID = 'opencage';
+const AWAIT_LABEL = '. . .';
+
+describe('geosearch-core:dist', () => {
+  it('should export OpenCageGeoSearchPlugin as a function', () => {
+    expect(OpenCageGeoSearchPlugin).to.be.a('function');
+  });
+
+  it('should create a plugin with the expected shape', () => {
+    const plugin = OpenCageGeoSearchPlugin();
+    expect(plugin).to.be.an('object');
+    expect(plugin.getSources).to.be.a('function');
+    expect(plugin.onSubmit).to.be.a('function');
+    expect(plugin.onReset).to.be.a('function');
+  });
+
+  it('should return empty results for an empty query', async () => {
+    const plugin = OpenCageGeoSearchPlugin();
+    const result = await plugin.getSources({ query: '' });
+    expect(result).to.be.an('array').that.is.empty;
+  });
+
+  it('should return empty results for a non-string query', async () => {
+    const plugin = OpenCageGeoSearchPlugin();
+    const result = await plugin.getSources({ query: 123 });
+    expect(result).to.be.an('array').that.is.empty;
+  });
+
+  it('should return the await label for a short query', async () => {
+    const plugin = OpenCageGeoSearchPlugin();
+    const result = await plugin.getSources({ query: 'aa' });
+    expect(result).to.have.lengthOf(1);
+    const items = result[0].getItems();
+    expect(items[0].formatted).to.equal(AWAIT_LABEL);
+  });
+
+  describe('with stubbed fetch', () => {
+    const query = 'greno';
+    const url = `https://api.opencagedata.com/geosearch?q=${query}`;
+
+    beforeEach(() => {
+      fetchMock.mockGlobal();
+      fetchMock.get(url, payload);
+    });
+
+    afterEach(() => {
+      fetchMock.clearHistory();
+      fetchMock.unmockGlobal();
+    });
+
+    it('should return results for a valid query', async () => {
+      const plugin = OpenCageGeoSearchPlugin({ key: 'a-real-key' });
+      const result = await plugin.getSources({ query });
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].sourceId).to.equal(SOURCE_ID);
+      expect(result[0].getItems).to.be.a('function');
+      expect(result[0].getItemInputValue).to.be.a('function');
+      expect(result[0].getItems()).to.be.an('array').that.is.not.empty;
+    });
+  });
+});

--- a/packages/geosearch-core/test/handleResult.spec.js
+++ b/packages/geosearch-core/test/handleResult.spec.js
@@ -100,7 +100,17 @@ describe('geosearch-core:handleResult', () => {
     expect(templates.item).to.be.a('function');
     expect(templates.noResults).to.be.a('function');
     expect(templates.footer).to.be.a('function');
-    expect(templates.item({ item: aarhus })).to.equal(aarhus.formatted);
+    const createElement = (tag, attrs, ...children) => ({
+      tag,
+      attrs,
+      children,
+    });
+    const itemEl = templates.item({ item: aarhus, createElement });
+    expect(itemEl).to.deep.equal({
+      tag: 'span',
+      attrs: null,
+      children: [aarhus.formatted],
+    });
     expect(templates.noResults()).to.equal(noResultsFR);
   });
 });

--- a/packages/geosearch-core/test/helpers/debounce.spec.js
+++ b/packages/geosearch-core/test/helpers/debounce.spec.js
@@ -1,29 +1,32 @@
-import { expect, describe, it } from 'vitest';
-import sinon from 'sinon';
+import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest';
 
 import { debouncePromise } from '../../src/helpers/debounce';
 
 describe('geosearch-core:debounce', () => {
-  it('should call the function after 500ms', (done) => {
-    const fn = sinon.spy();
-    const debounced = debouncePromise(fn, 500);
-    debounced();
-    expect(fn.calledOnce).to.be.false;
-    setTimeout(() => {
-      expect(fn.calledOnce).to.be.true;
-      done();
-    }, 600);
+  beforeEach(() => {
+    vi.useFakeTimers();
   });
 
-  it('should clear the timeout before running the function', (done) => {
-    const fn = sinon.spy();
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should call the function after 500ms', () => {
+    const fn = vi.fn();
+    const debounced = debouncePromise(fn, 500);
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(600);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('should clear the timeout before running the function', () => {
+    const fn = vi.fn();
     const debounced = debouncePromise(fn, 200);
     debounced();
-    expect(fn.calledOnce).to.be.false;
-    setTimeout(() => {
-      debounced();
-      expect(fn.calledOnce).to.be.false;
-      done();
-    }, 100);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/packages/geosearch-core/vitest.config.js
+++ b/packages/geosearch-core/vitest.config.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line import/no-unresolved
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', 'test/dist.spec.js'],
+  },
+});

--- a/packages/geosearch-core/vitest.dist.config.js
+++ b/packages/geosearch-core/vitest.dist.config.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line import/no-unresolved
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/dist.spec.js'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^12.6.0
         version: 12.6.0
       globals:
-        specifier: ^16.5.0
-        version: 16.5.0
+        specifier: ^17.6.0
+        version: 17.6.0
       isomorphic-unfetch:
         specifier: ^4.0.2
         version: 4.0.2
@@ -71,9 +71,6 @@ importers:
       sass:
         specifier: ^1.100.0
         version: 1.100.0
-      sinon:
-        specifier: ^21.1.2
-        version: 21.1.2
       vite:
         specifier: 7.3.2
         version: 7.3.2(sass@1.100.0)(yaml@2.8.2)
@@ -864,21 +861,25 @@ packages:
     resolution: {integrity: sha512-wgpPaTpQKl+cCkSuE5zamTVrg14mRvT+bLAeN/yHSUgMztvGxwl3Ll+K9DgEcktBo1PLECTWNkVaW8IAsJm4Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.1.3':
     resolution: {integrity: sha512-o9XmQehSPR2y0RD4evD+Ob3lNFuwsFOL5upVJqZ3rcE6GkJIFPg8SwEP5FaRIS5MwS04fxnek20NZ18BHjjV/g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.1.3':
     resolution: {integrity: sha512-ekcinyDNTa2huVe02T2SFMR8oArohozRbMGO19zftbObXXI4dLdoAuLNb3vK9Pe4vYOpkhfxBVkZvcWMmx7JdA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.1.3':
     resolution: {integrity: sha512-CqpRIJeIgELCqIgjtSsYnnLi6G0uqjbp/Pw9d7w4im4/NmJXqaE9gxpdHA1eowXLgAy9W1LkfzCPS8Q2IScPuQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.1.3':
     resolution: {integrity: sha512-YbuWb8KQsAR9G0+7b4HA16GV962/VWtRcdS7WY2yaScmPT2W5rObl528Y2j4DuB0j/MVZj12qJKrYfUyjL+UJA==}
@@ -974,36 +975,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1071,56 +1078,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -1176,15 +1194,6 @@ packages:
 
   '@sinclair/typebox@0.34.41':
     resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
-
-  '@sinonjs/commons@3.0.1':
-    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
-
-  '@sinonjs/fake-timers@15.3.2':
-    resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
-
-  '@sinonjs/samsam@10.0.2':
-    resolution: {integrity: sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1903,10 +1912,6 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
-    engines: {node: '>=0.3.1'}
-
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -2422,8 +2427,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@16.5.0:
-    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -3991,9 +3996,6 @@ packages:
     resolution: {integrity: sha512-Gw/FgHtrLM9WP8P5lLcSGh9OQcrTruWCELAiS48ik1QbL0cH+dfjomiRTUE9zzz+D1N6rOLkwXUvVmXZAsNE0Q==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  sinon@21.1.2:
-    resolution: {integrity: sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==}
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4231,14 +4233,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@4.0.8:
-    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
 
   type-fest@0.18.1:
     resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
@@ -5519,19 +5513,6 @@ snapshots:
 
   '@sinclair/typebox@0.34.41': {}
 
-  '@sinonjs/commons@3.0.1':
-    dependencies:
-      type-detect: 4.0.8
-
-  '@sinonjs/fake-timers@15.3.2':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-
-  '@sinonjs/samsam@10.0.2':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      type-detect: 4.1.0
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tufjs/canonical-json@2.0.0': {}
@@ -6362,8 +6343,6 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  diff@8.0.4: {}
-
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -7035,7 +7014,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@16.5.0: {}
+  globals@17.6.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -8794,13 +8773,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sinon@21.1.2:
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 15.3.2
-      '@sinonjs/samsam': 10.0.2
-      diff: 8.0.4
-
   slash@3.0.0: {}
 
   slash@5.1.0: {}
@@ -9060,10 +9032,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-detect@4.0.8: {}
-
-  type-detect@4.1.0: {}
 
   type-fest@0.18.1: {}
 


### PR DESCRIPTION
This pull request improves the Node.js CI workflow and refines the test setup for the `geosearch-core` package. 

It restructures the GitHub Actions workflow to separate build and test jobs, adds a new test for the built distribution artefact, updates dependencies, and removes unused packages. 

Additionally, it updates the `handleResult` template logic and modernises test utilities.

**CI/CD Workflow Improvements:**

- The Node.js GitHub Actions workflow is restructured to build the project once on Node.js LTS, upload the built artefact, and then test that artefact across multiple Node.js versions. This ensures that the distributed code is tested in environments matching user installations. 

**Testing Enhancements:**

- A new `test:dist` script and corresponding test file (`dist.spec.js`) are added to verify the built distribution of `geosearch-core`, including fetch mocking and plugin shape validation.
- The debounce helper test is refactored to use Vitest's built-in mocking utilities instead of Sinon, improving consistency and removing an unnecessary dependency.

